### PR TITLE
Add DESTDIR variable to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 PROGRAM = transactional-update-notifier
 VERSION = 1.0.0
 
+DESTDIR ?=
 PREFIX = /usr
 BINDIR := $(PREFIX)/bin
 USERUNITDIR := $(PREFIX)/lib/systemd/user
 USERPRESETDIR := $(PREFIX)/lib/systemd/user-preset
 BUILDDIR = build
 
-WITH_SYSTEMD_PRESET = yes
+WITH_SYSTEMD_PRESET = 1
 
 GO = go
 GOFLAGS ?= 
@@ -24,11 +25,11 @@ systemd.service:
 	sed -e 's|@bindir@|$(BINDIR)|' $(PROGRAM).service.in > $(BUILDDIR)/$(PROGRAM).service
 
 install: 
-	install -m 0755 -D $(BUILDDIR)/$(PROGRAM) $(BINDIR)/$(PROGRAM)
-	install -m 0644 -D $(BUILDDIR)/$(PROGRAM).service $(USERUNITDIR)/$(PROGRAM).service
+	install -m 0755 -D $(BUILDDIR)/$(PROGRAM) $(DESTDIR)$(BINDIR)/$(PROGRAM)
+	install -m 0644 -D $(BUILDDIR)/$(PROGRAM).service $(DESTDIR)$(USERUNITDIR)/$(PROGRAM).service
 
-ifeq ($(WITH_SYSTEMD_PRESET), yes)
-	install -m 0644 -D 96-$(PROGRAM).preset $(USERPRESETDIR)/96-$(PROGRAM).preset
+ifeq ($(WITH_SYSTEMD_PRESET), 1)
+	install -m 0644 -D 96-$(PROGRAM).preset $(DESTDIR)$(USERPRESETDIR)/96-$(PROGRAM).preset
 endif
 
 clean:


### PR DESCRIPTION
This is a common variable used by distributions that makes life easier to them.