### PR TITLE
Make notifications a little less urgent

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -40,7 +40,7 @@ func notify(input string) {
 	// an urgent notification, so we're sure that it will stick
 	// in the tray, and the user is notified.
 	hints := map[string]dbus.Variant{
-		"urgency":  dbus.MakeVariant(byte(2)),
+		"urgency":  dbus.MakeVariant(byte(1)),
 		"category": dbus.MakeVariant("device"),
 	}
 


### PR DESCRIPTION
An urgent notification is proving a little too persistant and annoying - for example interupting my presentation at FOSDEM while I was talking about how awesome transactional-updates on the desktop now is :)

So, lowering it down to Urgency Level 1 (Normal), which I think will make more sense